### PR TITLE
Added ws-wrapper and ws-server-wrapper to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ A curated list of WebSockets related principles and technologies.
 - [deepstream.io](https://deepstream.io/) - Open realtime server a fast, secure and scalable realtime server for mobile, web & iot.
 - [websocket-as-promised](https://github.com/vitalets/websocket-as-promised) - Promise-based W3C WebSocket wrapper: allows to use promises when connecting, disconnecting and messaging with WebSocket server.
 - [faye-websocket-node](https://github.com/faye/faye-websocket-node) - Standards-compliant WebSocket client and server.
+- [ws-wrapper](https://github.com/bminer/ws-wrapper) - Lightweight WebSocket wrapper that provides a socket.io-like event-handler API along with Promise-based requests.
+- [ws-server-wrapper](https://github.com/bminer/ws-server-wrapper) - Companion library for ws-wrapper for the server-side.
 
 ### Perl
 


### PR DESCRIPTION
Added some WebSocket and WebSocketServer wrapper libs to the list of Node.js libraries.  These can be used with native WebSocket implementations to provide an event-emitter API, Promise-based requests, and more.