### PR TITLE
Add the facil.io C library

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ A curated list of WebSockets related principles and technologies.
 - [Libwebsockets](https://libwebsockets.org) - It's a lightweight pure C library built to use minimal CPU and memory resources, and provide fast throughput in both directions as client or server.
 - [Libwebsock](https://github.com/payden/libwebsock) - C library for easy WebSockets server.
 - [Websocket](https://github.com/mortzdk/Websocket) -  Websocket server written in C.
+- [facil.io](http://facil.io) - A server/framework library for web applications, including Websockets and native pub/sub.
 
 ### C++
 <!-- #c-1 anchor -->


### PR DESCRIPTION
Hi!

Hice collection :-)

This PR is a suggestion to add the [facil.io](http://facil.io) library to this wonderful collection.

The facil.io library is also used as the engine for the Ruby [iodine HTTP/Websocket server](https://github.com/boazsegev/iodine) that allows Ruby applications to use native Websockets.

For your consideration,
   B.