### PR TITLE
Please add the iodine WebSocket/HTTP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ A curated list of WebSockets related principles and technologies.
 - [AnyCable](http://anycable.io/) - Polyglot replacement for Ruby WebSocket servers with Action Cable protocol.
 - [Em-websocket](https://github.com/igrigorik/em-websocket) - EventMachine based WebSocket server.
 - [Faye-websocket-ruby](https://github.com/faye/faye-websocket-ruby) - Standards-compliant WebSocket client and server.
+- [Iodine](https://github.com/boazsegev/iodine) - WebSocket/HTTP server with integrated pub/sub and optional Redis support.
 - [Websocket-driver-ruby](https://github.com/faye/websocket-driver-ruby) - WebSocket protocol handler with pluggable I/O.
 - [Websocket-ruby](https://github.com/imanel/websocket-ruby) - Universal Ruby library to handle WebSocket protocol.
 - [Scorched](https://github.com/wardrop/Scorched) - Light-weight web framework for Ruby.


### PR DESCRIPTION
Iodine is the Ruby port for the facil.io framework.

It's evented design, native pub/sub engine and C infrastructure allow for very high concurrency, which is ideal for persistent WebSocket connections.

Please consider adding iodine to this list.