### PR TITLE
Remove archived Erlang ninenines/bullet repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ A curated list of WebSockets related principles and technologies.
 
 - [Sockjs-erlang](https://github.com/sockjs/sockjs-erlang) - WebSocket emulation - Erlang server.
 - [Cowboy](https://github.com/ninenines/cowboy) - Small, fast, modular HTTP server written in Erlang.
-- [Bullet](https://github.com/ninenines/bullet) - Simple, reliable, efficient streaming for Cowboy.
 - [Kraken](https://github.com/Asana/kraken) - Distributed Pubsub Server for Realtime Apps.
 
 ### Go


### PR DESCRIPTION
The bullet project has been archived and is no longer being maintained.
https://github.com/ninenines/bullet