### PR TITLE
Add Sockette WebSocket client

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ A curated list of WebSockets related principles and technologies.
 - [ws-server-wrapper](https://github.com/bminer/ws-server-wrapper) - Companion library for ws-wrapper for the server-side.
 - [uws](https://github.com/uNetworking/uWebSockets.js) - Tiny WebSockets (access to the C++ library, µWebSockets, via Node.js)
 - [netflux](https://coast-team.github.io/netflux/) - JavaScript client and server side transport API based on WebRTC & WebSocket
+- [Sockette](https://github.com/lukeed/sockette) - WebSocket client that will automatically reconnect if the connection is lost.
 
 ### Perl
 


### PR DESCRIPTION
Sockette is a tiny wrapper around WebSocket that will automatically reconnect if the connection is lost!

**Note:**
Links are not already sorted in alphabetical order under Node.js category. I think this should be done in a separate commit.
