### PR TITLE
Add entry for the Rust Actix web framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ A curated list of WebSockets related principles and technologies.
 
 ### Rust
 
+- [Actix](https://actix.rs/docs/websockets) - A Rust web framework with support for the Websocket Protocol 
 - [Websocket Core](https://github.com/bitwyre/websocket_core) - Rust Websocket server for periodic message broadcast
 
 ### Swift


### PR DESCRIPTION
Adds an entry to the awesome list of web socket resources fro the Rust language Actix web framework which has support [built in support for Websockets](https://actix.rs/docs/websockets).