### PR TITLE
Add wtx

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ A curated list of WebSockets related principles and technologies.
 - [Tokio-Tungstenite](https://github.com/snapview/tokio-tungstenite) - Tokio binding for Tungstenite, the Lightweight stream-based WebSocket implementation
 - [Fastwebsockets](https://github.com/denoland/fastwebsockets) - A fast RFC6455 WebSocket server implementation 
 - [Ratchet](https://github.com/swimos/ratchet) - Ratchet is a fast, lightweight and fully asynchronous implementation of the WebSocket protocol with support for extensions and Deflate.
+- [wtx](https://github.com/c410-f3r/wtx) - Client and server with encryption support.
 
 ### Swift
 


### PR DESCRIPTION
`wtx` is a RFC6455 and RFC7692 implementation written in Rust. There is also a CLI binary that supports limited WebSocket interactions.

Some benchmarks with balanced loads are available at https://c410-f3r.github.io/wtx-bench/.