### PR TITLE
Add KubeStellar Console to Go section

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ A curated list of WebSockets related principles and technologies.
 - [Centrifuge](https://github.com/centrifugal/centrifuge) - Real-time messaging library for Go with scalability in mind.
 - [GWS](https://github.com/lxzan/gws) - Simple, fast, reliable websocket server & client, supports running over tcp/kcp/unix domain socket.
 - [Velaros](https://github.com/RobertWHurst/Velaros) - A lightweight framework with HTTP-style routing, bidirectional messaging, and middleware.
+- [KubeStellar Console](https://github.com/kubestellar/console) - AI-powered multi-cluster Kubernetes dashboard using WebSockets for real-time cluster communication and live observability streams.
 
 ### Haskell
 


### PR DESCRIPTION
Adds [KubeStellar Console](https://console.kubestellar.io) to the **Go** section under Tools per Language.

KubeStellar Console uses WebSockets extensively for real-time communication between the browser and its kc-agent backend, enabling live cluster observability, streaming logs, and bidirectional AI assistant interactions.

- 🔗 Live: https://console.kubestellar.io
- 📦 Source: https://github.com/kubestellar/console
- � WebSocket: kc-agent on port 8585 (gorilla/websocket)
- 📜 License: Apache-2.0
- 🏛️ CNCF Sandbox project (under KubeStellar)