### PR TITLE
Add DeepAlpha to Python section

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ A curated list of WebSockets related principles and technologies.
 - [Starlette](https://www.starlette.io/websockets/)
 - [Simple Http Server](https://github.com/keijack/python-simple-http-server) A simple HTTP server, including support of numerous websocket events like `on_text_message`, `on_binary_message` etc. And even `on_binary_frame`.
 - [Picows](https://picows.readthedocs.io/en/stable/) - Ultra-fast WebSocket client and server library for asyncio.
+- [DeepAlpha](https://github.com/stefanoviana/deepalpha) - AI crypto trading bot that uses WebSocket connections to 12 exchanges for real-time market data streaming and order execution via CCXT.
 - [WebRockets](https://github.com/ploMP4/webrockets) - Rust-powered WebSocket server with Django integration, message pattern matching, Pydantic validation, and more.
 
 ### R


### PR DESCRIPTION
## What is DeepAlpha?

[DeepAlpha](https://github.com/stefanoviana/deepalpha) is an open-source AI crypto trading bot that heavily relies on WebSocket connections for real-time market data streaming from 12 exchanges.

### WebSocket Usage
- Real-time orderbook streaming via WebSocket (L2 data)
- Live ticker and trade feeds via WebSocket
- Order execution through exchange WebSocket APIs
- All connections managed through CCXT's unified WebSocket interface
- Supports Binance, Bybit, Coinbase, OKX, and 8 more exchanges

Added to the Python section alongside other WebSocket tools and frameworks.

Thank you for maintaining this list!